### PR TITLE
[CSVCS] Migrating to Github Package Manager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@xplor/apollo-contributors

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "[DEPENDABOT] "
+
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "[DEPENDABOT] "

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+@xplor:registry=https://npm.pkg.github.com
+always-auth=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@xplortech/apollo-foundation",
+  "name": "@xplor/apollo-foundation",
   "version": "0.1.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@xplortech/apollo-foundation",
+      "name": "@xplor/apollo-foundation",
       "version": "0.1.0-alpha.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "files": [
     "build"
-  ]
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@xplortech/apollo-foundation",
+  "name": "@xplor/apollo-foundation",
   "version": "0.1.0-alpha.0",
-  "description": "",
+  "description": "The design tokens for Xplor and Xplor's Apollo design library",
   "main": "index.js",
   "scripts": {
     "build": "style-dictionary build"


### PR DESCRIPTION
This PR migrates the npm package from this project to Github's Package registry, as well as migrates our namespace to `@xplor` and adds configuration for dependabot and codeowners

Dependency management:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R17): Added configuration for Dependabot to maintain dependencies for GitHub Actions and npm with daily updates.

Project metadata:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R4): Updated the package name to `@xplor/apollo-foundation` and added a description for the design tokens and Apollo design library.

Package publishing:

* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1-R3): Configured the npm registry and authentication token for publishing to GitHub Packages.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L24-R27): Added `publishConfig` to specify the npm registry for publishing.

Ownership:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1): Assigned the `@xplor/apollo-contributors` team as code owners.