### PR TITLE
[XPAT-74] Adding GHAs for PR linting and releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,11 @@ space_after_control_statements = true
 space_after_anonymous_functions = true
 spaces_in_brackets = false
 
+[*.yml]
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
 # No standard.  Please document a standard if different from .js
 [*.md]
 indent_style = space

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,37 @@
+name-template: Release v$RESOLVED_VERSION
+tag-template: "v$RESOLVED_VERSION"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+      - "feature"
+      - "enhancement"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧰 Maintenance"
+    label: "chore"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+category-template: "### $TITLE"
+
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,18 @@
+# Maintenance release notes and manages the versioning based on labels
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          publish: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,14 @@
+name: PR lint
+
+on:
+  pull_request:
+    types: ["opened", "edited", "reopened", "synchronize"]
+
+jobs:
+  pr-lint:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: seferov/pr-lint-action@v1.2.0
+        with:
+          title-regex: ^(\[(?!NO-TICKET|NO TICKET|NOTICKET)([A-Z0-9]|\s{1}){0,10}(-\d+)?\])+(\ )(?!.*[^\u0000-\u007F]+[\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]+]).*$

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,21 +1,25 @@
 name: Release and Publish
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       TAG_NAME:
+        description: 'TEMP: The tag name'
         type: string
         required: true
 
       TAG_NUMBER:
+        description: 'TEMP: The tag number'
         type: string
         required: true
 
       ID:
+        description: 'TEMP: The ID'
         type: string
         required: true
 
       IS_DRYRUN:
+        description: 'TEMP: Is this a Dry Run?'
         type: boolean
         default: false
 

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,0 +1,77 @@
+name: Release and Publish
+
+on:
+  workflow_call:
+    inputs:
+      TAG_NAME:
+        type: string
+        required: true
+
+      TAG_NUMBER:
+        type: string
+        required: true
+
+      ID:
+        type: string
+        required: true
+
+      IS_DRYRUN:
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+  attestations: write
+  id-token: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        with:
+          token: '${{ env.GITHUB_TOKEN }}'
+
+      - name: 🛠 Setting Up Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: 🤖 Installing Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: "npm"
+
+      - name: 🤖 Installing Dependencies
+        run: npm ci
+
+      - name: 💅 Building CSS and Stencil
+        run: npm run build
+
+      # - name: Tag and Release the latest
+      #   id: tag_and_release_latest
+      #   if: ${{ inputs.IS_DRYRUN == false}}
+      #   run: |
+      #     npm version ${{ inputs.tag_number }} -m "[Release] Apollo Foundations %s"
+      #     git push origin main
+      - name: "Dry Run: Tag and Release the latest"
+        id: tag_and_release_latest_dry_run
+        # if: ${{ inputs.IS_DRYRUN == true}}
+        run: |
+          cat << EOF
+          npm version ${{ inputs.tag_number }} -m "[Release] Apollo Foundations %s"
+          git push origin main
+          EOF
+
+      - name: Publish Release
+        if: ${{ inputs.IS_DRYRUN  == false}}
+        uses: eregon/publish-release@v1
+        with:
+          release_id: ${{ inputs.id }}
+

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: oleksiyrudenko/gha-git-credentials@v2-latest
-        with:
-          token: '${{ env.GITHUB_TOKEN }}'
-
       - name: 🛠 Setting Up Checkout
         uses: actions/checkout@v4
         with:
           token: ${{ env.GITHUB_TOKEN }}
+
+      - uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        with:
+          token: '${{ env.GITHUB_TOKEN }}'
 
       - name: 🤖 Installing Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,23 +1,23 @@
 name: Release and Publish
 
-on: push
-  # workflow_call:
-  #   inputs:
-  #     TAG_NAME:
-  #       type: string
-  #       required: true
+on:
+  workflow_call:
+    inputs:
+      TAG_NAME:
+        type: string
+        required: true
 
-  #     TAG_NUMBER:
-  #       type: string
-  #       required: true
+      TAG_NUMBER:
+        type: string
+        required: true
 
-  #     ID:
-  #       type: string
-  #       required: true
+      ID:
+        type: string
+        required: true
 
-  #     IS_DRYRUN:
-  #       type: boolean
-  #       default: false
+      IS_DRYRUN:
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -54,15 +54,16 @@ jobs:
       - name: 💅 Building CSS and Stencil
         run: npm run build
 
-      # - name: Tag and Release the latest
-      #   id: tag_and_release_latest
-      #   if: ${{ inputs.IS_DRYRUN == false}}
-      #   run: |
-      #     npm version ${{ inputs.tag_number }} -m "[Release] Apollo Foundations %s"
-      #     git push origin main
+      - name: Tag and Release the latest
+        id: tag_and_release_latest
+        if: ${{ inputs.IS_DRYRUN == false}}
+        run: |
+          npm version ${{ inputs.tag_number }} -m "[Release] Apollo Foundations %s"
+          git push origin main
+
       - name: "Dry Run: Tag and Release the latest"
         id: tag_and_release_latest_dry_run
-        # if: ${{ inputs.IS_DRYRUN == true}}
+        if: ${{ inputs.IS_DRYRUN == true}}
         run: |
           cat << EOF
           npm version ${{ inputs.tag_number }} -m "[Release] Apollo Foundations %s"
@@ -70,7 +71,7 @@ jobs:
           EOF
 
       - name: Publish Release
-        if: ${{ inputs.IS_DRYRUN  == false}}
+        if: ${{ inputs.IS_DRYRUN == false}}
         uses: eregon/publish-release@v1
         with:
           release_id: ${{ inputs.id }}

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,27 +1,23 @@
 name: Release and Publish
 
-on:
-  workflow_dispatch:
-    inputs:
-      TAG_NAME:
-        description: 'TEMP: The tag name'
-        type: string
-        required: true
+on: push
+  # workflow_call:
+  #   inputs:
+  #     TAG_NAME:
+  #       type: string
+  #       required: true
 
-      TAG_NUMBER:
-        description: 'TEMP: The tag number'
-        type: string
-        required: true
+  #     TAG_NUMBER:
+  #       type: string
+  #       required: true
 
-      ID:
-        description: 'TEMP: The ID'
-        type: string
-        required: true
+  #     ID:
+  #       type: string
+  #       required: true
 
-      IS_DRYRUN:
-        description: 'TEMP: Is this a Dry Run?'
-        type: boolean
-        default: false
+  #     IS_DRYRUN:
+  #       type: boolean
+  #       default: false
 
 permissions:
   contents: write

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,0 +1,60 @@
+name: Trigger Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      IS_DRYRUN:
+        type: boolean
+        description: "Is this a Dry Run?"
+        default: false
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.get_draft_release_meta.outputs.tag_name }}
+      tag_number: ${{ steps.get_draft_release_meta.outputs.tag_number }}
+      id: ${{ steps.get_draft_release_meta.outputs.id }}
+      is_prerelease: ${{ steps.get_draft_release_meta.outputs.is_prerelease }}
+    steps:
+      - name: Get draft release meta
+        id: get_draft_release_meta
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // gets the first 100 releases (more than enough)
+            const releaseList = await github.rest.repos.listReleases({
+              repo: context.repo.repo,
+              owner: context.repo.owner,
+              per_page: '100',
+              page: 1
+            });
+
+            // find the first draft release
+            const { tag_name, id, prerelease = false } = releaseList.data.find(release => release.draft);
+
+            // sets the tag_number and id to this step's outputs
+            core.setOutput('tag_name', tag_name);
+            core.setOutput('tag_number', tag_name.replace('v', ''));
+            core.setOutput('id', id);
+            core.setOutput('is_prerelease', prerelease === true);
+
+  release_and_publish:
+    name: Release and publish
+    uses: ./.github/workflows/release-and-publish.yml
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
+    needs: release
+    with:
+      TAG_NAME: ${{ needs.release.outputs.tag_name }}
+      TAG_NUMBER: ${{ needs.release.outputs.tag_number }}
+      ID: ${{ needs.release.outputs.id }}
+      IS_PRERELEASE: ${{ needs.release.outputs.is_prerelease == true }}
+      IS_DRYRUN: ${{ inputs.IS_DRYRUN == 'true' }}


### PR DESCRIPTION
This pull request introduces several changes to automate and streamline the release process, add linting for pull requests, and update the editor configuration. The most important changes include the addition of workflows for drafting, triggering, and publishing releases, the introduction of a pull request linting workflow, and updates to the `.editorconfig` file.

### Release Automation:
* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR1-R37): Added a configuration for the Release Drafter to automate the creation of release notes based on labels and categories.
* [`.github/workflows/draft-release.yml`](diffhunk://#diff-3d80a0bd2aa867253847d98ff0fddb8982d61587bee3ddfb9906f4aafbe55329R1-R18): Added a workflow to draft release notes and manage versioning based on labels.
* [`.github/workflows/trigger-release.yml`](diffhunk://#diff-adba9a186548df150482709a71fd748b421904c1240d28470ca9934c77c4fb74R1-R60): Added a workflow to trigger the release process, including fetching draft release metadata and invoking the release and publish workflow.
* [`.github/workflows/release-and-publish.yml`](diffhunk://#diff-f1aa31b040aa63ad53feecf5f41bcf0699b50576cc2b1f1ed23daf0d12b5fe8dR1-R77): Added a workflow to handle the release and publishing process, including setting up the environment, building the project, and publishing the release.

### Pull Request Linting:
* [`.github/workflows/pr-lint.yml`](diffhunk://#diff-96c941d62860ad493e2ef6e2e641b5cdda1373729143a0a72a44f11f46895e4dR1-R14): Added a workflow to lint pull request titles to ensure they follow the specified regex pattern.

### Editor Configuration:
* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR30-R34): Updated the configuration to trim trailing whitespace and set indentation style and size for YAML files.