### PR TITLE
[XPL-0] Fix swapped light/dark token values and hex6 alpha handling

### DIFF
--- a/src/builder/hooks/transforms/__tests__/hex6.test.ts
+++ b/src/builder/hooks/transforms/__tests__/hex6.test.ts
@@ -15,10 +15,15 @@ describe('hex6 transform', () => {
         expect(hex6.filter!({} as TransformedToken)).toBe(false);
     });
 
-    it('strips alpha from 8-digit hex', () => {
-        expect(hex6.transform({ value: '#aabbccdd' } as TransformedToken)).toBe('#aabbcc');
+    it('converts 8-digit hex with non-opaque alpha to rgba', () => {
+        expect(hex6.transform({ value: '#aabbccdd' } as TransformedToken)).toBe('rgba(170, 187, 204, 0.87)');
+        expect(hex6.transform({ value: '#FFFFFF0D' } as TransformedToken)).toBe('rgba(255, 255, 255, 0.05)');
+        expect(hex6.transform({ value: '#302D3B80' } as TransformedToken)).toBe('rgba(48, 45, 59, 0.5)');
+    });
+
+    it('converts 8-digit hex with opaque alpha to 6-digit hex', () => {
         expect(hex6.transform({ value: '#000000ff' } as TransformedToken)).toBe('#000000');
-        expect(hex6.transform({ value: '#ABCDEF99' } as TransformedToken)).toBe('#ABCDEF');
+        expect(hex6.transform({ value: '#ABCDEFff' } as TransformedToken)).toBe('#ABCDEF');
     });
 
     it('leaves 6-digit hex unchanged', () => {

--- a/src/builder/hooks/transforms/hex6.ts
+++ b/src/builder/hooks/transforms/hex6.ts
@@ -5,10 +5,21 @@ export const hex6 = {
     type: 'value',
     filter: (token) => token.type === 'color',
     transform: ({ value }) => {
-        // Strip alpha channel if it's an 8-digit hex
-        if (value && typeof value === 'string') {
+        if (typeof value === 'string') {
             const match = value.match(/^#([0-9a-fA-F]{6})([0-9a-fA-F]{2})$/i);
-            if (match) return `#${match[1]}`; // Return 6-digit hex without alpha
+
+            if (match) {
+                const rgbHex = match[1];
+                const alpha = Number((parseInt(match[2], 16) / 255).toFixed(2));
+
+                if (alpha === 1) return `#${rgbHex}`;
+
+                const red = parseInt(rgbHex.slice(0, 2), 16);
+                const green = parseInt(rgbHex.slice(2, 4), 16);
+                const blue = parseInt(rgbHex.slice(4, 6), 16);
+
+                return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+            }
         }
 
         return value;

--- a/src/tokens/brands/apollo/color/dark/icon.json
+++ b/src/tokens/brands/apollo/color/dark/icon.json
@@ -2,19 +2,19 @@
   "dark": {
     "icon": {
       "default": {
-        "value": "{color.neutral.1000}",
+        "value": "{color.neutral.0}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "Default icon color and when paired with default or strong text."
+        "comment": "Default icon color and when paired with default or strong text"
       },
       "subtle": {
         "value": "{color.neutral.500}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "Use when paired with subtle text colors or inactive actions."
+        "comment": "Use when paired with subtle text colors or inactive actions"
       },
       "inverse": {
-        "value": "{color.neutral.0}",
+        "value": "{color.neutral.1000}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
         "comment": "Inverse color icons (white on dark surfaces, dark on light surfaces)"
@@ -23,46 +23,46 @@
         "value": "{color.neutral.1000}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "Dark icons on light backgrounds that do not mode switch."
+        "comment": "Dark icons on light backgrounds that do not mode switch"
       },
       "inverse_on_dark": {
         "value": "{color.neutral.0}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "White icons on dark backgrounds that do not mode switch."
+        "comment": "White icons on dark backgrounds that do not mode switch"
       },
       "disabled": {
-        "value": "{color.neutral.600}",
+        "value": "{color.neutral.500}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "Use for icons paired with disabled text or actions."
+        "comment": "Use for icons paired with disabled text or actions"
       },
       "brand": {
-        "value": "{color.brand.primary.xplorange}",
+        "value": "{color.orange.300}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "Use for brand logos and icons paired with primary brand color."
+        "comment": "Use for brand logos and icons paired with primary brand color"
       },
       "negative": {
-        "value": "{color.red.700}",
+        "value": "{color.red.300}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "Use for icons with negative sentiment, or paired with negative text."
+        "comment": "Use for icons with negative sentiment, or paired with negative text"
       },
       "warning": {
-        "value": "{color.yellow.600}",
+        "value": "{color.yellow.200}",
         "type": "color",
         "scope": "Stroke Color",
-        "comment": "Highlight accented borders."
+        "comment": "Highlight accented borders"
       },
       "positive": {
-        "value": "{color.green.700}",
+        "value": "{color.green.300}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
-        "comment": "Use for icons in a positive sentiment or paired with positive text."
+        "comment": "Use for icons in a positive sentiment or paired with positive text"
       },
       "information": {
-        "value": "{color.purple.700}",
+        "value": "{color.purple.300}",
         "type": "color",
         "scope": "Frame Fill, Shape Fill, Stroke Color",
         "comment": "Use for icons communicating information"

--- a/src/tokens/brands/apollo/color/dark/text.json
+++ b/src/tokens/brands/apollo/color/dark/text.json
@@ -2,25 +2,25 @@
   "dark": {
     "text": {
       "strong": {
-        "value": "{color.neutral.1100}",
+        "value": "{color.neutral.0}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Bold text color, use for display text styles, page headings"
       },
       "default": {
-        "value": "{color.neutral.900}",
+        "value": "{color.neutral.50}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use for primary text color such as body or titles in sentence case"
       },
       "subdued": {
-        "value": "{color.neutral.600}",
+        "value": "{color.neutral.500}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use for subdued text such as descriptions and details"
       },
       "inverse": {
-        "value": "{color.neutral.0}",
+        "value": "{color.neutral.1000}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use on inverse surfaces (light on dark surface, dark on light surface)"
@@ -38,13 +38,13 @@
         "comment": "Use on text on a dark surface that does not mode switch"
       },
       "positive": {
-        "value": "{color.green.700}",
+        "value": "{color.green.300}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use on positive sentiment text"
       },
       "negative": {
-        "value": "{color.red.700}",
+        "value": "{color.red.300}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use on negative sentiment text"
@@ -57,19 +57,19 @@
       },
       "link": {
         "default": {
-          "value": "{color.purple.700}",
+          "value": "{color.purple.300}",
           "type": "color",
           "scope": "Text Fill",
           "comment": "Use for link text"
         },
         "hovered": {
-          "value": "{color.purple.800}",
+          "value": "{color.purple.400}",
           "type": "color",
           "scope": "Text Fill",
           "comment": "Use for default badge text"
         },
         "visited": {
-          "value": "{color.pink.800}",
+          "value": "{color.pink.300}",
           "type": "color",
           "scope": "Text Fill",
           "comment": "Use for yellow badge text"

--- a/src/tokens/brands/apollo/color/light/icon.json
+++ b/src/tokens/brands/apollo/color/light/icon.json
@@ -1,19 +1,19 @@
 {
-"icon": {
+  "icon": {
     "default": {
-      "value": "{color.neutral.0}",
+      "value": "{color.neutral.1000}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "Default icon color and when paired with default or strong text"
+      "comment": "Default icon color and when paired with default or strong text."
     },
     "subtle": {
       "value": "{color.neutral.500}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "Use when paired with subtle text colors or inactive actions"
+      "comment": "Use when paired with subtle text colors or inactive actions."
     },
     "inverse": {
-      "value": "{color.neutral.1000}",
+      "value": "{color.neutral.0}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
       "comment": "Inverse color icons (white on dark surfaces, dark on light surfaces)"
@@ -22,46 +22,46 @@
       "value": "{color.neutral.1000}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "Dark icons on light backgrounds that do not mode switch"
+      "comment": "Dark icons on light backgrounds that do not mode switch."
     },
     "inverse_on_dark": {
       "value": "{color.neutral.0}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "White icons on dark backgrounds that do not mode switch"
+      "comment": "White icons on dark backgrounds that do not mode switch."
     },
     "disabled": {
-      "value": "{color.neutral.500}",
+      "value": "{color.neutral.600}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "Use for icons paired with disabled text or actions"
+      "comment": "Use for icons paired with disabled text or actions."
     },
     "brand": {
-      "value": "{color.orange.300}",
+      "value": "{color.brand.primary.xplorange}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "Use for brand logos and icons paired with primary brand color"
+      "comment": "Use for brand logos and icons paired with primary brand color."
     },
     "negative": {
-      "value": "{color.red.300}",
+      "value": "{color.red.700}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "Use for icons with negative sentiment, or paired with negative text"
+      "comment": "Use for icons with negative sentiment, or paired with negative text."
     },
     "warning": {
-      "value": "{color.yellow.200}",
+      "value": "{color.yellow.600}",
       "type": "color",
       "scope": "Stroke Color",
-      "comment": "Highlight accented borders"
+      "comment": "Highlight accented borders."
     },
     "positive": {
-      "value": "{color.green.300}",
+      "value": "{color.green.700}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
-      "comment": "Use for icons in a positive sentiment or paired with positive text"
+      "comment": "Use for icons in a positive sentiment or paired with positive text."
     },
     "information": {
-      "value": "{color.purple.300}",
+      "value": "{color.purple.700}",
       "type": "color",
       "scope": "Frame Fill, Shape Fill, Stroke Color",
       "comment": "Use for icons communicating information"

--- a/src/tokens/brands/apollo/color/light/text.json
+++ b/src/tokens/brands/apollo/color/light/text.json
@@ -1,49 +1,49 @@
 {
-"text": {
+  "text": {
     "strong": {
-      "value": "{color.neutral.0}",
+      "value": "{color.neutral.1100}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Bold text color, use for display text styles, page headings"
     },
     "default": {
-      "value": "{color.neutral.50}",
+      "value": "{color.neutral.900}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Use for primary text color such as body or titles in sentence case"
     },
     "subdued": {
-      "value": "{color.neutral.500}",
+      "value": "{color.neutral.600}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Use for subdued text such as descriptions and details"
     },
     "inverse": {
-      "value": "{color.neutral.1000}",
+      "value": "{color.neutral.0}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Use on inverse surfaces (light on dark surface, dark on light surface)"
     },
-    "inverse_on_light": {
+    "inverse-on-light": {
       "value": "{color.neutral.1000}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Use on a light surface that does not mode switch"
     },
-    "inverse_on_dark": {
+    "inverse-on-dark": {
       "value": "{color.neutral.0}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Use on text on a dark surface that does not mode switch"
     },
     "positive": {
-      "value": "{color.green.300}",
+      "value": "{color.green.700}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Use on positive sentiment text"
     },
     "negative": {
-      "value": "{color.red.300}",
+      "value": "{color.red.700}",
       "type": "color",
       "scope": "Text Fill",
       "comment": "Use on negative sentiment text"
@@ -56,19 +56,19 @@
     },
     "link": {
       "default": {
-        "value": "{color.purple.300}",
+        "value": "{color.purple.700}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use for link text"
       },
       "hovered": {
-        "value": "{text.strong}",
+        "value": "{color.purple.800}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use for default badge text"
       },
       "visited": {
-        "value": "{text.strong}",
+        "value": "{color.pink.800}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use for yellow badge text"
@@ -100,13 +100,13 @@
         "comment": "Use for blue badge text"
       },
       "gray": {
-        "value": "{color.purple.400}",
+        "value": "{text.strong}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use on link hover states"
       },
       "blue": {
-        "value": "{color.pink.300}",
+        "value": "{text.strong}",
         "type": "color",
         "scope": "Text Fill",
         "comment": "Use on links that have been visited"


### PR DESCRIPTION
# PR Type

- [ ] :rocket: Feature
- [x] :bug: Bug
- [ ] :broom: Other

_If feature_, these checkboxes are required:

- [ ] Component styles
- [ ] Component implementation (Stencil)
- [ ] Component readme.md
- [ ] Tests
- [ ] Storybook with toggles for all properties
- [ ] Link to documentation (in Frontify)
- [ ] Changelog entry

---

<!--
  Enter issue(s) number that this PR closes.
-->Closes: #

---

## Summary

Two issues are fixed in this PR:

### 1. Apollo light/dark token values were swapped
The contents of the Apollo brand `text.json` and `icon.json` source files were accidentally swapped between the `light/` and `dark/` directories — light mode files contained dark mode values and vice versa. This was verified against the Figma source of truth. Additionally, several specific values within these files were corrected:
- `text/link/hovered`, `text/link/visited` — pointed to wrong color references
- `text/badge/gray`, `text/badge/blue` — pointed to wrong color references

**Files changed:**
- `src/tokens/brands/apollo/color/light/text.json`
- `src/tokens/brands/apollo/color/dark/text.json`
- `src/tokens/brands/apollo/color/light/icon.json`
- `src/tokens/brands/apollo/color/dark/icon.json`

### 2. hex6 transform now preserves alpha as rgba()
Previously, the `hex6` transform stripped the alpha channel from all 8-digit hex values (e.g. `#FFFFFF0D` → `#FFFFFF`), discarding transparency information. Now it correctly converts non-opaque 8-digit hex to `rgba()` format (e.g. `#FFFFFF0D` → `rgba(255, 255, 255, 0.05)`) and only strips the alpha suffix when fully opaque (`ff`).

**Files changed:**
- `src/builder/hooks/transforms/hex6.ts`
- `src/builder/hooks/transforms/__tests__/hex6.test.ts`

## Testing Steps

- Storybook: https://xplor-apollo.herokuapp.com/

1. Run `npm run build` — confirm build succeeds without errors
2. Run `npm test` — confirm all 84 tests pass
3. Inspect `build/apollo/css/variables.css`:
   - Verify `:root` (light mode) contains expected light values (e.g. `--xpl-text-strong: #1b1325`)
   - Verify `.dark` selector contains expected dark values (e.g. `--xpl-text-strong: #ffffff`)
4. Verify tokens with alpha channels now output `rgba()` format (e.g. search for `rgba(` in the built CSS)

## Supplemental Materials

Token values were cross-referenced against the Apollo Foundation Figma file to confirm correctness.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect generated design-token outputs across Apollo themes and alter color serialization to `rgba()`, which may cause downstream visual diffs or consumers that assume hex-only colors to break.
> 
> **Overview**
> Fixes Apollo brand `light`/`dark` `text` and `icon` token values that were effectively inverted, updating numerous references (including link hover/visited and badge colors) so each mode points at the intended palette entries.
> 
> Updates the `color/hex6` Style Dictionary transform to **preserve transparency**: 8-digit hex values now convert to `rgba(r, g, b, a)` when alpha is not fully opaque, and only collapse to 6-digit hex when alpha is `ff`. Tests are updated to cover both cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a473c9a9157381035209831a4de3188e0ac81fe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->